### PR TITLE
ATP-22 ajuste, conflito com grid de email

### DIFF
--- a/Jira/ATP-22.feature
+++ b/Jira/ATP-22.feature
@@ -58,7 +58,7 @@ Feature: ATP-22
         And the user selects the text field with name: "Receives XML"
         And the user writes "" to the selected text field and hits tab key
         And the user selects the text field with name: "Receives Bankslip"
-        And the user writes "" to the selected text field and hits tab key
+        And the user writes "" to the selected text field
 
     Scenario: 4.Save
         Given the user clicks the "Save" main action button on the right panel


### PR DESCRIPTION
Ajuste devido a alteração realizada nas funções GESBPC e GESBPS. A instrução tab fazia com que o ATP caísse na nova grid de e-mails.