### PR TITLE
ATP-98 ajustes na SADD para não criar vencimentos

### DIFF
--- a/SAM-MIG/xq-gesxqadd-ipi-pis-cofins.feature
+++ b/SAM-MIG/xq-gesxqadd-ipi-pis-cofins.feature
@@ -127,8 +127,8 @@ Feature: xq-gesxqadd-ipi-pis-cofins
         And the user selects the date field with X3 field name: "XQSADDI1_DTVENC"
         And the user writes a generated date in the selected date field using the value "T+1"
         And the user clicks the "Create" main action button on the right panel
-
         Given the user clicks the "SEFAZ" action button on the header drop down
+        Then the user clicks the "No" opinion in the alert box
         When a log panel appears
         And the user clicks the "Close page" main action button on the right panel
         #Verificar status da nota (6 = Autorizada)

--- a/SAM-MIG/xq-s-flow-sadd-sih.feature
+++ b/SAM-MIG/xq-s-flow-sadd-sih.feature
@@ -138,10 +138,9 @@ Feature:xq-s-flow-sadd-sih
         And the user selects the text field with X3 field name: "XQSADDI1_DTVENC"
         And the user writes "12/31/23" to the selected text field and hits tab key
 
-
         And the user clicks the "Create" main action button on the right panel
-
         Given the user clicks the "SEFAZ" action button on the header drop down
+        Then the user clicks the "No" opinion in the alert box
         When a log panel appears
         And the user clicks the "Close page" main action button on the right panel
         #Verificar status da nota (6 = Autorizada)


### PR DESCRIPTION
Adicionada a instrução para fechar a tela de criação de vencimentos (adicionada recentemente na Nota Complementar).