### PR TITLE
ATP Ajustes - Alterado conteúdo do scenario outline

### DIFF
--- a/SAM-MIG/xq-p-flow-poh-al.feature
+++ b/SAM-MIG/xq-p-flow-poh-al.feature
@@ -7,9 +7,9 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 08/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 08/02/2021
-# - Status : Automated
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
+# - Status : In progress
 ###########################################################################
 
 Feature: xq-p-flow-poh-al
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-al
         And the user writes "BR005" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         Then the user writes "52" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines
         And the user selects editable table row number: <LIN>
         And the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell
@@ -93,7 +93,8 @@ Feature: xq-p-flow-poh-al
     Scenario: 7. Resume
         Given the user clicks the Close page action icon on the header panel
         And the user clicks the "Resume" tab selected by title
-        And the user selects the text field with X3 field name: "XQPOH2_TTICMSST"
+        And the user selects the text field with name: "IPI + ICMS ST value"
+        # VERIFICAR SE ESTÁ UTILIZANDO A VTAX/RTAX CORRETA PARA CÁLCULO DO ST
         And the value of the selected text field is "231.37"
         Then the user clicks the Close page action icon on the header panel
 

--- a/SAM-MIG/xq-p-flow-poh-pih-ef-01.feature
+++ b/SAM-MIG/xq-p-flow-poh-pih-ef-01.feature
@@ -7,9 +7,9 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 04/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 04/02/2021
-# - Status : In progress
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
+# - Status : Automated
 ###########################################################################
 
 Feature: xq-p-flow-poh-pih-ef-01
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pih-ef-01
         And the user writes "BR001" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "110" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pih-ef-02.feature
+++ b/SAM-MIG/xq-p-flow-poh-pih-ef-02.feature
@@ -7,9 +7,9 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 04/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 04/02/2021
-# - Status : In progress
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
+# - Status : Automated
 ###########################################################################
 
 Feature: xq-p-flow-poh-pih-ef-02
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pih-ef-02
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "111" to the selected text field and hits tab key
-
-    Scenario Outline: 12. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 12. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pih-ef-03.feature
+++ b/SAM-MIG/xq-p-flow-poh-pih-ef-03.feature
@@ -7,9 +7,9 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 04/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 04/02/2021
-# - Status : In progress
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
+# - Status : Automated
 ###########################################################################
 
 Feature: xq-p-flow-poh-pih-ef
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pih-ef
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "111" to the selected text field and hits tab key
-
-    Scenario Outline: 24. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 24. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pih-imp-icms.feature
+++ b/SAM-MIG/xq-p-flow-poh-pih-imp-icms.feature
@@ -8,8 +8,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 09/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 09/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -37,10 +37,10 @@ Feature: xq-p-flow-poh-pih-imp-icms
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "117" to the selected text field and hits tab key
-
-    Scenario Outline: 12. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 12. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pih-imp-ii.feature
+++ b/SAM-MIG/xq-p-flow-poh-pih-imp-ii.feature
@@ -8,8 +8,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 09/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 09/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -37,10 +37,10 @@ Feature: xq-p-flow-poh-pih-imp-ii
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "118" to the selected text field and hits tab key
-
-    Scenario Outline: 12. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 12. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pih-imp-imptx.feature
+++ b/SAM-MIG/xq-p-flow-poh-pih-imp-imptx.feature
@@ -8,8 +8,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 10/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 10/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -37,10 +37,10 @@ Feature: xq-p-flow-poh-pih-imp-imptx
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "127" to the selected text field and hits tab key
-
-    Scenario Outline: 12. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 12. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pih-imp-txac.feature
+++ b/SAM-MIG/xq-p-flow-poh-pih-imp-txac.feature
@@ -8,8 +8,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 10/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 10/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -37,10 +37,10 @@ Feature: xq-p-flow-poh-pih-imp-txac
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "128" to the selected text field and hits tab key
-
-    Scenario Outline: 12. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 12. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pth-01.feature
+++ b/SAM-MIG/xq-p-flow-poh-pth-01.feature
@@ -7,8 +7,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 02/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 03/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pth-01
         And the user writes "BR001" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "113" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pth-02.feature
+++ b/SAM-MIG/xq-p-flow-poh-pth-02.feature
@@ -7,8 +7,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 02/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 03/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pth-02
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "111" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pth-03.feature
+++ b/SAM-MIG/xq-p-flow-poh-pth-03.feature
@@ -7,8 +7,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 02/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 03/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pth-03
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "111" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pth-ef-01.feature
+++ b/SAM-MIG/xq-p-flow-poh-pth-ef-01.feature
@@ -7,8 +7,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 04/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 04/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pth-ef-01
         And the user writes "BR001" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "110" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pth-ef-02.feature
+++ b/SAM-MIG/xq-p-flow-poh-pth-ef-02.feature
@@ -7,8 +7,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 04/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 04/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pth-ef-02
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "111" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell

--- a/SAM-MIG/xq-p-flow-poh-pth-ef-03.feature
+++ b/SAM-MIG/xq-p-flow-poh-pth-ef-03.feature
@@ -7,8 +7,8 @@
 # - Legislation: BRA
 # - Created by : Daniela Anile
 # - Created date : 04/02/2021
-# - Updated by : Daniela Anile
-# - Updated date : 04/02/2021
+# - Updated by : Fausto A Neto
+# - Updated date : 31/07/2024
 # - Status : Automated
 ###########################################################################
 
@@ -36,10 +36,10 @@ Feature: xq-p-flow-poh-pth-ef-03
         And the user writes "PT006" to the selected text field and hits tab key
         And the user selects the text field with name: "Fiscal operation"
         And the user writes "111" to the selected text field and hits tab key
-
-    Scenario Outline: 3. Lines POH
         Given the user clicks the "Lines" tab selected by title
         And the user selects the fixed data table for x3 field name: "WE3ALL2_ARRAY_NBLIG"
+
+    Scenario Outline: 3. Lines POH
         And the user selects editable table row number: <LIN>
         When the user selects last fixed cell with X3 field name: "WE3ALL2_ITMREF"
         And the user adds the text <ITMREF> in selected cell


### PR DESCRIPTION
Ajuste na forma de chamar a tabela de linhas das POHs, para que o posicionamento do cursor fique fora do Scenario Outline da feature. 